### PR TITLE
Move in Bugzilla integration

### DIFF
--- a/source/dlangbot/app.d
+++ b/source/dlangbot/app.d
@@ -6,7 +6,7 @@ import dlangbot.github;
 import dlangbot.trello;
 import dlangbot.utils;
 
-public import dlangbot.bugzilla : bugzillaURL;
+public import dlangbot.bugzilla : bugzillaLogin, bugzillaPassword, bugzillaURL;
 public import dlangbot.github_api   : githubAPIURL, githubAuth, githubHookSecret;
 public import dlangbot.trello   : trelloAPIURL, trelloAuth, trelloSecret;
 public import dlangbot.twitter : oAuth, tweet, twitterURL, twitterEnabled;

--- a/source/dlangbot/app.d
+++ b/source/dlangbot/app.d
@@ -276,6 +276,20 @@ void handlePR(string action, PullRequest* _pr)
         logDebug("[github/handlePR](%s): updating trello card", _pr.pid);
         updateTrelloCard(action, pr.htmlURL, refs, descs);
     }
+
+    if (action == "merged")
+    {
+        import std.algorithm.iteration : filter, map;
+        import std.array : array;
+
+        auto ids = refs.filter!(r => r.fixed).map!(r => r.id).array;
+        if (ids.length)
+            closeIssues(ids,
+                "%s pull request #%d \"%s\" was merged:\n\n%s".format(
+                    pr.baseRepoSlug, pr.number, pr.title,
+                    pr.htmlURL,
+                ));
+    }
 }
 
 void handleReview(string action, PullRequest* _pr)
@@ -384,6 +398,8 @@ else void main(string[] args)
     oAuth.config.consumerKeySecret = environment["TWITTER_CONSUMER_KEY_SECRET"];
     oAuth.config.accessToken = environment["TWITTER_ACCESS_TOKEN"];
     oAuth.config.accessTokenSecret = environment["TWITTER_ACCESS_TOKEN_SECRET"];
+    bugzillaLogin = environment["BUGZILLA_LOGIN"];
+    bugzillaPassword = environment["BUGZILLA_PASSWORD"];
     twitterEnabled = true;
 
     // workaround for stupid openssl.conf on Heroku

--- a/test/bugzilla.d
+++ b/test/bugzilla.d
@@ -18,10 +18,11 @@ unittest
         },
         "/trello/1/search?query=name:%22Issue%2017564%22&"~trelloAuth,
         "/bugzilla/buglist.cgi?bug_id=17564&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority",
-        "/bugzilla/jsonrpc.cgi?params=%7B%22Bugzilla_login%22%3A%22bugzilla%40test.org%22%2C%22resolution%22%3A%22FIXED%22%2C%22comment%22%3A%7B%22body%22%3A%22dlang%2Fphobos%20pull%20request%20%234963%20%5C%22%5BDEMO%20for%20DIP1005%5D%20Converted%20imports%20to%20selective%20imports%20in%20std.array%5C%22%20was%20merged%3A%5Cn%5Cnhttps%3A%2F%2Fgithub.com%2Fdlang%2Fphobos%2Fpull%2F4963%22%7D%2C%22Bugzilla_password%22%3A%22BUGZILLA_DUMMY_PW%22%2C%22status%22%3A%22RESOLVED%22%2C%22ids%22%3A%5B17564%5D%7D&method=Bug.update",
+        "/bugzilla/jsonrpc.cgi",
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
-            assert(req.method == HTTPMethod.GET);
-            auto j = Json(["result": Json("Success.")]);
+            assert(req.method == HTTPMethod.POST);
+            assert(req.json["method"].get!string == "Bug.update");
+            auto j = Json(["error" : Json(null), "result" : Json.emptyObject]);
             res.writeJsonBody(j);
         },
     );

--- a/test/bugzilla.d
+++ b/test/bugzilla.d
@@ -1,0 +1,30 @@
+import utils;
+
+@("after-merge-close-issue-bugzilla")
+unittest
+{
+    setAPIExpectations(
+        "/github/repos/dlang/phobos/pulls/4963/commits", (ref Json j) {
+            j[0]["commit"]["message"] = "Fix Issue 17564";
+         },
+        "/github/repos/dlang/phobos/issues/4963/comments",
+        "/github/repos/dlang/phobos/issues/4963/labels",
+        (scope HTTPServerRequest req, scope HTTPServerResponse res){
+            res.writeJsonBody(Json.emptyArray);
+        },
+        "/github/repos/dlang/phobos/issues/4963/labels",
+        (scope HTTPServerRequest req, scope HTTPServerResponse res){
+            res.writeVoidBody;
+        },
+        "/trello/1/search?query=name:%22Issue%2017564%22&"~trelloAuth,
+        "/bugzilla/buglist.cgi?bug_id=17564&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority",
+        "/bugzilla/jsonrpc.cgi?params=%7B%22Bugzilla_login%22%3A%22bugzilla%40test.org%22%2C%22resolution%22%3A%22FIXED%22%2C%22comment%22%3A%7B%22body%22%3A%22dlang%2Fphobos%20pull%20request%20%234963%20%5C%22%5BDEMO%20for%20DIP1005%5D%20Converted%20imports%20to%20selective%20imports%20in%20std.array%5C%22%20was%20merged%3A%5Cn%5Cnhttps%3A%2F%2Fgithub.com%2Fdlang%2Fphobos%2Fpull%2F4963%22%7D%2C%22Bugzilla_password%22%3A%22BUGZILLA_DUMMY_PW%22%2C%22status%22%3A%22RESOLVED%22%2C%22ids%22%3A%5B17564%5D%7D&method=Bug.update",
+        (scope HTTPServerRequest req, scope HTTPServerResponse res){
+            assert(req.method == HTTPMethod.GET);
+            auto j = Json(["result": Json("Success.")]);
+            res.writeJsonBody(j);
+        },
+    );
+
+    postGitHubHook("dlang_phobos_merged_4963.json");
+}

--- a/test/comments.d
+++ b/test/comments.d
@@ -279,7 +279,7 @@ unittest
     postGitHubHook("dlang_phobos_synchronize_4921.json");
 }
 
-@("do-not-readd-labels-2-#112")
+@("do-not-read-labels-2-#112")
 unittest
 {
     setAPIExpectations(
@@ -303,7 +303,7 @@ unittest
     postGitHubHook("dlang_phobos_synchronize_5519.json");
 }
 
-@("do-not-readd-labels-3-#112")
+@("do-not-read-labels-3-#112")
 unittest
 {
     setAPIExpectations(

--- a/test/utils.d
+++ b/test/utils.d
@@ -50,6 +50,8 @@ shared static this()
     scalewayOrg = "aa435976-67f1-455c-b988-f4dc04c91f40";
     hcloudAuth = "Bearer BDc2RZCKKvgdyF6Dgex1kg4NGwkScI9xzBZqGJemkR4GopohwatiH0IRD2iTg61o";
     dlangbotAgentAuth = "Bearer fjSL8ITFkOxS5PF9p5lM41mox";
+    bugzillaLogin = "bugzilla@test.org";
+    bugzillaPassword = "BUGZILLA_DUMMY_PW";
 
     // start our hook server
     auto settings = new HTTPServerSettings;

--- a/test/utils.d
+++ b/test/utils.d
@@ -111,10 +111,9 @@ auto payloadServer(scope HTTPServerRequest req, scope HTTPServerResponse res)
     }
     else
     {
-        scope(failure) {
-            writeln("Remaining expected URLs:", apiExpectations.map!(x => x.url));
-        }
-        assert(0, "Request for unexpected URL received: " ~ req.requestURL);
+        logError("Remaining expected URLs: %s", apiExpectations.map!(x => x.url));
+        logError("Request for unexpected URL received: '%s'", req.requestURL);
+        assert(0);
     }
 
     res.statusCode = expectation.respStatusCode;
@@ -140,7 +139,8 @@ auto payloadServer(scope HTTPServerRequest req, scope HTTPServerResponse res)
 
     if (!filePath.exists)
     {
-        assert(0, "Please create payload: " ~ filePath);
+        logError("Please create payload: " ~ filePath);
+        assert(0);
     }
     else
     {


### PR DESCRIPTION
Here's a first (untested) draft for the Bugzilla integration.

Any thoughts on how to test this?

Some things left to do:

- What if the issue is already closed? Need to check if the Bugzilla API errors out. We should post a comment regardless.
- Check the comment formatting and see if we want to put any more data there, such as the commit message which contains the reference to the bug in question. Will need to split up closing per-issue instead of in bulk.
- Needs the Bugzilla auth in environment as for the other services.