### PR TITLE
dlangbot.github: Omit "dub fetch digger"

### DIFF
--- a/source/dlangbot/github.d
+++ b/source/dlangbot/github.d
@@ -99,7 +99,6 @@ If your PR contains non-trivial changes, please [reference a Bugzilla issue](htt
 If you don't have a [local development environment setup](https://wiki.dlang.org/Starting_as_a_Contributor), you can use [Digger](https://github.com/CyberShadow/Digger) to test this PR:
 
 ```sh
-dub fetch digger
 dub run digger -- build \"%s + %s#%d\"
 ```
 ".format(pr.base.ref_, pr.base.repo.name, pr.number));


### PR DESCRIPTION
When running "dub run digger" with a clean cache, recent Dub versions now show:

    Package 'digger' was not found locally but is available online:
    ---
    Description: A tool to build D and bisect old D versions
    Version: 3.0.0-alpha-9
    ---
    Do you want to fetch 'digger' now? [Y/n]:

This makes the line mostly redundant, so remove it to save vertical space.