### PR TITLE
Only try to registerMemoryHandler when possible

### DIFF
--- a/source/dlangbot/app.d
+++ b/source/dlangbot/app.d
@@ -447,14 +447,15 @@ shared static this()
     import std.process : environment;
     version (linux)
     {
-        // register memory error handler on heroku
-        if ("DYNO" in environment)
+        // Only Glibc x86 / x86_64 supports this method, so check if defined
+        import etc.linux.memoryerror;
+        static if (is(typeof(registerMemoryErrorHandler)))
         {
-            import etc.linux.memoryerror : registerMemoryErrorHandler;
-            registerMemoryErrorHandler();
+            // register memory error handler on heroku
+            if ("DYNO" in environment)
+                registerMemoryErrorHandler();
         }
     }
-
 }
 
 version (unittest) {}


### PR DESCRIPTION
Trying to compile this module with an alternative libc,
such as Musl, resulted in a compile error because of the
selective import.