### PR TITLE
Test: Rename utility function to work around warning

### DIFF
--- a/test/cronjob.d
+++ b/test/cronjob.d
@@ -63,7 +63,7 @@ unittest
             ));
         },
     );
-    testCronDaily(repositories);
+    runCronDailyTest(repositories);
 }
 
 @("stalled-sticks-on-labelling")
@@ -89,7 +89,7 @@ unittest
         },
     );
 
-    testCronDaily(repositories);
+    runCronDailyTest(repositories);
 }
 
 @("no-label-updates-with-inactivity")
@@ -108,7 +108,7 @@ unittest
         "/github/repos/dlang/phobos/pulls/2526/comments",
     );
 
-    testCronDaily(repositories);
+    runCronDailyTest(repositories);
 }
 
 @("merge-state-refreshed")
@@ -136,7 +136,7 @@ unittest
         },
     );
 
-    testCronDaily(repositories);
+    runCronDailyTest(repositories);
 }
 
 @("blocked-mergeable-removes-needs-rebase")
@@ -162,7 +162,7 @@ unittest
         },
     );
 
-    testCronDaily(repositories);
+    runCronDailyTest(repositories);
 }
 
 @("more-than-two-failures-requires-work")
@@ -187,5 +187,5 @@ unittest
         },
     );
 
-    testCronDaily(repositories);
+    runCronDailyTest(repositories);
 }

--- a/test/utils.d
+++ b/test/utils.d
@@ -412,7 +412,7 @@ void postAgentShutdownCheck(string hostname, int line = __LINE__, string file = 
     req.dropBody;
 }
 
-void testCronDaily(string[] repositories, int line = __LINE__, string file = __FILE__)
+void runCronDailyTest(string[] repositories, int line = __LINE__, string file = __FILE__)
 {
     import dlangbot.app : cronDaily;
     import dlangbot.cron : CronConfig;


### PR DESCRIPTION
unit-threaded was complained with the following message:

> Warning:
> testCronDaily passes the criteria for a value-parameterized test
> function but doesn't have the appropriate value UDAs.
> Consider changing its name or annotating it with @DontTest