### PR TITLE
stop mentioning users when they create a PR

### DIFF
--- a/source/dlangbot/github.d
+++ b/source/dlangbot/github.d
@@ -66,13 +66,13 @@ string formatComment(in ref PullRequest pr, in IssueRef[] refs, in Issue[] descs
     if (isMember)
     {
         app.formattedWrite(
-`Thanks for your pull request, @%s!
+`Thanks for your pull request, %s!
 `, pr.user.login, pr.repoSlug);
     }
     else
     {
         app.formattedWrite(
-"Thanks for your pull request and interest in making D better, @%s!  We are looking forward to reviewing it, and you should be hearing from a maintainer soon.
+"Thanks for your pull request and interest in making D better, %s!  We are looking forward to reviewing it, and you should be hearing from a maintainer soon.
 Please verify that your PR follows this checklist:
 
 - My PR is fully covered with tests (you can see the coverage diff by visiting the _details_ link of the codecov check)

--- a/source/dlangbot/github.d
+++ b/source/dlangbot/github.d
@@ -63,11 +63,14 @@ string formatComment(in ref PullRequest pr, in IssueRef[] refs, in Issue[] descs
         .deserializeJson!(GHUser[])
         .canFind!(l => l.login == pr.user.login);
 
+    // Avoid actually mentioning users when referring to them
+    auto userRef = `**@<!-- -->%s**`.format(pr.user.login);
+
     if (isMember)
     {
         app.formattedWrite(
 `Thanks for your pull request, %s!
-`, pr.user.login, pr.repoSlug);
+`, userRef, pr.repoSlug);
     }
     else
     {
@@ -85,7 +88,7 @@ Please see [CONTRIBUTING.md](https://github.com/%s/blob/master/CONTRIBUTING.md) 
 ---
 
 If you have addressed all reviews or aren't sure how to proceed, don't hesitate to ping us with a simple comment.",
-                           pr.user.login, pr.repoSlug);
+                           userRef, pr.repoSlug);
     }
 
     static immutable bugzillaReferences = ["dlang/dmd", "dlang/druntime", "dlang/phobos",

--- a/test/comments.d
+++ b/test/comments.d
@@ -81,7 +81,7 @@ unittest
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
             assert(req.method == HTTPMethod.PATCH);
             auto body_= req.json["body"].get!string;
-            assert(body_.canFind("@andralex"));
+            assert(body_.canFind("**@<!-- -->andralex**"));
             assert(!body_.canFind("Auto-close | Bugzilla"), "Shouldn't contain bug header");
             assert(!body_.canFind("/show_bug.cgi?id="), "Shouldn't contain a Bugzilla reference");
         }
@@ -107,7 +107,7 @@ unittest
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
             assert(req.method == HTTPMethod.PATCH);
             auto body_= req.json["body"].get!string;
-            assert(body_.canFind("@andralex"));
+            assert(body_.canFind("**@<!-- -->andralex**"));
             assert(!body_.canFind("Auto-close | Bugzilla"), "Shouldn't contain bug header");
             assert(!body_.canFind("/show_bug.cgi?id="), "Shouldn't contain a Bugzilla reference");
         }
@@ -139,7 +139,7 @@ unittest
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
             assert(req.method == HTTPMethod.PATCH);
             auto body_= req.json["body"].get!string;
-            assert(body_.canFind("@andralex"));
+            assert(body_.canFind("**@<!-- -->andralex**"));
         },
         "/github/repos/dlang/phobos/issues/4921/labels",
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
@@ -208,7 +208,7 @@ unittest
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
             assert(req.method == HTTPMethod.PATCH);
             auto body_= req.json["body"].get!string;
-            assert(body_.canFind("@andralex"));
+            assert(body_.canFind("**@<!-- -->andralex**"));
         },
         "/trello/1/search?query=name:%22Issue%208573%22&"~trelloAuth,
         "/bugzilla/jsonrpc.cgi", // Bug.comments
@@ -317,7 +317,7 @@ unittest
         "/github/repos/dlang/phobos/issues/comments/262784442",
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
             assert(req.method == HTTPMethod.PATCH);
-            assert(req.json["body"].get!string.canFind("Thanks for your pull request, @andralex!"));
+            assert(req.json["body"].get!string.canFind("Thanks for your pull request, **@<!-- -->andralex**!"));
             // don't show the the default contributors advice
             assert(!req.json["body"].get!string.canFind("CONTRIBUTING"));
         },
@@ -479,7 +479,7 @@ unittest
             (scope HTTPServerRequest req, scope HTTPServerResponse res){
                 assert(req.method == HTTPMethod.PATCH);
                 auto body_ = req.json["body"].get!string;
-                assert(body_.canFind("@andralex"));
+                assert(body_.canFind("**@<!-- -->andralex**"));
                 assert(!body_.canFind("Auto-close | Bugzilla"), "Shouldn't contain bug header");
                 assert(!body_.canFind("/show_bug.cgi?id="), "Shouldn't contain a Bugzilla reference");
             }


### PR DESCRIPTION
- creates notifications that seem fairly pointless given that people just created the PR
- not sure people with mail workflows have a different perspective on this