### PR TITLE
dlangbot.github_api: Add GHReview.State.DISMISSED

### DIFF
--- a/source/dlangbot/github_api.d
+++ b/source/dlangbot/github_api.d
@@ -380,7 +380,7 @@ struct GHReview
     GHUser user;
     @name("commit_id") string commitId;
     string body_;
-    enum State { APPROVED, CHANGES_REQUESTED, COMMENTED }
+    enum State { APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED }
     @byName State state;
     @byName @name("author_association") CommentAuthorAssociation authorAssociation;
 }


### PR DESCRIPTION
```
Fixes deserialization of events for when a pull request review is 
dismissed.

Hypothetically should fix auto-merging when someone dismisses the last
review requesting changes and all other conditions for auto-merge are
satisfied.
```