### PR TITLE
Remove travis-ci badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Dlang-Bot
 
-[![Travis build status](https://travis-ci.org/dlang/dlang-bot.svg?branch=master)](https://travis-ci.org/dlang/dlang-bot)
 [![Codecov](https://img.shields.io/codecov/c/github/dlang/dlang-bot/master.svg)](https://codecov.io/gh/dlang/dlang-bot)
 
 <img alt="dlang-bot" height="200px" src="public/img/dlang_bot.png" />


### PR DESCRIPTION

TravisCI has ceased to work since the migration to dotcom.

Someone who has relevant access should create a new project for dlang-bot on https://buildkite.com/dlang