### PR TITLE
Use unit-threaded --debug switch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         if: matrix.dc != 'ldc-latest'
         run: |
           # Tests are neither random- nor parallelizable atm., so use a --single serial thread.
-          dub test --compiler=$DC  -- --single --trace
+          dub test --compiler=$DC  -- --single --trace --debug
 
       - name: Test with coverage
         if: matrix.dc == 'ldc-latest'
@@ -31,7 +31,7 @@ jobs:
           COVERAGE: true
         run: |
           # Mirrot the previous `run` step but with `--build=unittest-cov`
-          dub test --compiler=$DC --build=unittest-cov -- --single --trace
+          dub test --compiler=$DC --build=unittest-cov -- --single --trace --debug
 
       - name: Upload code coverage
         if: matrix.dc == 'ldc-latest'

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Improve the bot
 Run the testsuite:
 
 ```
-dub test -- --single --debug --trace
+dub test -- --single --debug --trace --debug
 ```
 
 Missing a feature?


### PR DESCRIPTION
If an unhandled exception occurs in a vibe-core asynchronous task, it will never be displayed, because:

1. `unit-threaded` buffers output (`std.stdio.stdout` is reopened to `/dev/null`)
2. vibe.d calls `abort` after trying to print the exception.

Work around this by updating our documentation and CI commands to use `--debug`, which disables `unit-threaded` output mucking.